### PR TITLE
Add required meta tags for social media

### DIFF
--- a/source/wp-content/themes/wporg-developer-blog/functions.php
+++ b/source/wp-content/themes/wporg-developer-blog/functions.php
@@ -8,6 +8,7 @@ namespace WordPressdotorg\Theme\Developer_Blog;
 add_action( 'wp_enqueue_scripts',       __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'wp_head',                  __NAMESPACE__ . '\output_head_tags', 2 );
 add_filter( 'render_block_core/search', __NAMESPACE__ . '\search_block_add_search_action', 10, 2 );
+add_filter( 'excerpt_length',           __NAMESPACE__ . '\customize_excerpt_length', 10 );
 
 /**
  * Enqueue scripts and styles.
@@ -56,46 +57,15 @@ function output_head_tags() {
 		'twitter:site'   => '@WordPress',
 	];
 
-	$desc = '';
+	$excerpt = '';
 
 	if ( is_singular() ) {
-		$post = get_queried_object();
-		if ( $post ) {
-			$desc = $post->post_content;
-		}
+		$excerpt = get_the_excerpt();
 	}
 
-	// Actually set field values for description.
-	if ( ! empty( $desc ) ) {
-		$desc = wp_strip_all_tags( $desc );
-		$desc = str_replace( '&nbsp;', ' ', $desc );
-		$desc = preg_replace( '/\s+/', ' ', $desc );
-
-		// Trim down to <150 characters based on full words.
-		if ( strlen( $desc ) > 150 ) {
-			$truncated = '';
-			$words = preg_split( "/[\n\r\t ]+/", $desc, -1, PREG_SPLIT_NO_EMPTY );
-
-			while ( $words ) {
-				$word = array_shift( $words );
-				if ( strlen( $truncated ) + strlen( $word ) >= 141 ) { /* 150 - strlen( ' &hellip;' ) */
-					break;
-				}
-
-				$truncated .= $word . ' ';
-			}
-
-			$truncated = trim( $truncated );
-
-			if ( $words ) {
-				$truncated .= '&hellip;';
-			}
-
-			$desc = $truncated;
-		}
-
-		$fields['description']    = $desc;
-		$fields['og:description'] = $desc;
+	if ( ! empty( $excerpt ) ) {
+		$fields['description']    = $excerpt;
+		$fields['og:description'] = $excerpt;
 	}
 
 	// Output fields.
@@ -108,4 +78,14 @@ function output_head_tags() {
 			esc_attr( $content )
 		);
 	}
+}
+
+/**
+ * Filter the except length to 20 words.
+ *
+ * @param int $length Excerpt length.
+ * @return int (Maybe) modified excerpt length.
+ */
+function customize_excerpt_length( $length ) {
+	return 20;
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/wporg-developer-blog/issues/18

The preview of some posts couldn't be correctly displayed on some social media, so in this PR, required meta tags are added.

Note: A [must-have](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image) twitter tag `twitter:card` is not added because it has already been added by the plugin `social image generator`.

## Screenshot (Tested on sandbox)
#### Added by this PR ⬇️ 
![Screen Shot 2023-01-20 at 1 58 30 AM](https://user-images.githubusercontent.com/18050944/213528392-6c6baed5-c1c2-4c19-a156-e4039845b577.png)
#### Added by social image generator ⬇️ 
![Screen Shot 2023-01-20 at 1 58 47 AM](https://user-images.githubusercontent.com/18050944/213528425-7ddb61c6-4e14-4973-8713-fdfc30559d26.png)

## How to test
1. Locally or on the sandbox, choose a post.
2. Check the dev console if newly added tags are there.
3. Front page doesn't have a description tag at the moment.

## TODO
1. Does the front page need a description? What should it be? ([ref](https://github.com/WordPress/wporg-developer/blob/ec6722b8aac9827a3a4086f19a52d2dd72635514/source/wp-content/themes/wporg-developer-2023/inc/head.php#L115))
2. After the deployment, check if the issue is totally fixed as it was found out earlier that Slack still couldn't display the preview of a [post](https://developer.wordpress.org/news/2023/01/some-very-cool-things-can-happen-when-you-hit-enter-in-a-block/) correctly (Discord has no such problem though) while in the meantime the preview of the post mentioned in the issue was shown without any problem on my side. (Any thoughts? Perhaps it's img size restriction, I'll look further into it in this direction)
<img width="766" alt="image" src="https://user-images.githubusercontent.com/18050944/213530016-56a43289-768a-4a44-a790-fe222705190a.png">
