### PR TITLE
Add tags to homepage feature section.

### DIFF
--- a/source/wp-content/themes/wporg-developer-blog/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-developer-blog/patterns/front-page.php
@@ -40,6 +40,8 @@
 					<!-- wp:post-author-name {"isLink":true,"fontSize":"small"} /-->
 
 					<!-- wp:post-date /-->
+
+					<!-- wp:post-terms {"term":"post_tag"} /-->
 				</div>
 				<!-- /wp:group -->
 			</div>


### PR DESCRIPTION
Fixes #56 

This PR adds the Post Terms block to the post meta of the feature section on the homepage. 

<img width="1123" alt="image" src="https://github.com/WordPress/wporg-developer-blog/assets/4832319/cb960fd3-7240-4510-a55d-ef7862a23490">
