### PR TITLE
Update font styles to match Developer Resources redesign

### DIFF
--- a/source/wp-content/themes/wporg-developer-blog/functions.php
+++ b/source/wp-content/themes/wporg-developer-blog/functions.php
@@ -36,7 +36,7 @@ function enqueue_assets() {
 		/* translators: Subsets can be any of cyrillic, cyrillic-ext, greek, greek-ext, vietnamese, latin, latin-ext. */
 		$subsets = _x( 'Latin', 'Heading font subsets, comma separated', 'wporg' );
 		// All headings.
-		global_fonts_preload( 'IBM Plex Sans, IBM Plex Sans SemiBold', $subsets );
+		global_fonts_preload( 'EB Garamond, Inter', $subsets );
 	}
 }
 

--- a/source/wp-content/themes/wporg-developer-blog/patterns/footer.php
+++ b/source/wp-content/themes/wporg-developer-blog/patterns/footer.php
@@ -11,8 +11,8 @@
 	<div class="wp-block-columns alignwide">
 		<!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}}} -->
 		<div class="wp-block-column">
-			<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"large"} -->
-			<h2 class="wp-block-heading has-large-font-size" style="font-style:normal;font-weight:400"><?php esc_html_e( 'Have an idea for a new post?', 'wporg' ); ?></h2>
+			<!-- wp:heading {"style":{"typography":{"fontStyle":"normal"}},"fontSize":"large"} -->
+			<h2 class="wp-block-heading has-large-font-size" style="font-style:normal"><?php esc_html_e( 'Have an idea for a new post?', 'wporg' ); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|40"}}}} -->
@@ -55,8 +55,8 @@
 
 		<!-- wp:column {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}}} -->
 		<div class="wp-block-column">
-			<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"large"} -->
-			<h2 class="wp-block-heading has-large-font-size" style="font-style:normal;font-weight:400"><?php esc_html_e( 'Subscribe to the Blog', 'wporg' ); ?></h2>
+			<!-- wp:heading {"style":{"typography":{"fontStyle":"normal"}},"fontSize":"large"} -->
+			<h2 class="wp-block-heading has-large-font-size" style="font-style:normal;"><?php esc_html_e( 'Subscribe to the Blog', 'wporg' ); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:jetpack/subscriptions {"subscribePlaceholder":"Email Address","showSubscribersTotal":true,"borderRadius":2,"borderWeight":0,"className":"wp-block-jetpack-subscriptions wp-block-jetpack-subscriptions__supports-newline is-style-compact","style":{"spacing":{"padding":{"right":"0","left":"0"}}}} /-->

--- a/source/wp-content/themes/wporg-developer-blog/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-developer-blog/patterns/front-page.php
@@ -9,8 +9,8 @@
 <div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"bottom"}} -->
 	<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)">
-		<!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"50px","fontStyle":"normal","fontWeight":"400"}},"fontFamily":"ibm-plex-sans"} -->
-		<h1 class="wp-block-heading has-ibm-plex-sans-font-family" style="font-size:50px;font-style:normal;font-weight:400"><?php esc_html_e( 'Developer Blog', 'wporg' ); ?></h1>
+		<!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"50px","fontStyle":"normal","fontWeight":"400"}},"fontFamily":"eb-garamond"} -->
+		<h1 class="wp-block-heading has-eb-garamond-font-family" style="font-size:50px;font-style:normal;font-weight:400"><?php esc_html_e( 'Developer Blog', 'wporg' ); ?></h1>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"style":{"typography":{"lineHeight":"2.3"}},"textColor":"white"} -->
@@ -31,7 +31,8 @@
 				<!-- wp:heading -->
 					<h2 class="wp-block-heading screen-reader-text"><?php esc_html_e( 'Featured post', 'wporg' ); ?></h2>
 				<!-- /wp:heading -->
-				<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"top":"0"}}},"fontSize":"heading-2"} /-->
+				<!-- wp:post-title {"level":3,"isLink":true,"fontSize":"heading-2","fontFamily":"inter","style":{"spacing":{"margin":{"top":"0"}},"typography":{"fontStyle":"normal","fontWeight":"600"}}} /-->
+
 
 				<!-- wp:post-excerpt /-->
 
@@ -87,7 +88,7 @@
 					<div class="wp-block-group">
 						<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"default"}} -->
 						<div class="wp-block-group">
-							<!-- wp:post-title {"isLink":true,"fontSize":"heading-3"} /-->
+							<!-- wp:post-title {"isLink":true,"fontSize":"heading-4","fontFamily":"inter","style":{"typography":{"fontStyle":"normal","fontWeight":"600"}}} /-->
 
 							<!-- wp:pattern {"slug":"wporg-developer-blog/post-meta"} /-->
 						</div>

--- a/source/wp-content/themes/wporg-developer-blog/patterns/sidebar-all-posts.php
+++ b/source/wp-content/themes/wporg-developer-blog/patterns/sidebar-all-posts.php
@@ -8,7 +8,7 @@
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">
 	<!-- wp:heading {"level":1,"fontSize":"heading-2","style":{"typography":{"fontStyle":"normal","fontWeight":"600"}}} -->
-	<h1 class="wp-block-heading has-heading-2-font-size" style="font-weight: 600"><?php esc_html_e( 'All	posts', 'wporg' ); ?></h1>
+	<h1 class="wp-block-heading has-heading-2-font-size" style="font-weight: 600"><?php esc_html_e( 'All posts', 'wporg' ); ?></h1>
 	<!-- /wp:heading -->
 
 	<!-- wp:search {"label":"<?php esc_html_e( 'Search', 'wporg' ); ?>","showLabel":false,"placeholder":"<?php esc_html_e( 'Type your search keyword', 'wporg' ); ?>","width":100,"widthUnit":"%","buttonText":"<?php esc_html_e( 'Search', 'wporg' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"query":{"post_type":"post"}} /-->

--- a/source/wp-content/themes/wporg-developer-blog/patterns/sidebar-all-posts.php
+++ b/source/wp-content/themes/wporg-developer-blog/patterns/sidebar-all-posts.php
@@ -7,8 +7,8 @@
 ?>
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">
-	<!-- wp:heading {"level":1,"fontSize":"heading-2"} -->
-	<h1 class="wp-block-heading has-heading-2-font-size"><?php esc_html_e( 'All posts', 'wporg' ); ?></h1>
+	<!-- wp:heading {"level":1,"fontSize":"heading-2","style":{"typography":{"fontStyle":"normal","fontWeight":"600"}}} -->
+	<h1 class="wp-block-heading has-heading-2-font-size" style="font-weight: 600"><?php esc_html_e( 'All	posts', 'wporg' ); ?></h1>
 	<!-- /wp:heading -->
 
 	<!-- wp:search {"label":"<?php esc_html_e( 'Search', 'wporg' ); ?>","showLabel":false,"placeholder":"<?php esc_html_e( 'Type your search keyword', 'wporg' ); ?>","width":100,"widthUnit":"%","buttonText":"<?php esc_html_e( 'Search', 'wporg' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"query":{"post_type":"post"}} /-->

--- a/source/wp-content/themes/wporg-developer-blog/patterns/sidebar-search.php
+++ b/source/wp-content/themes/wporg-developer-blog/patterns/sidebar-search.php
@@ -7,7 +7,7 @@
 ?>
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group">
-	<!-- wp:query-title {"type":"search","fontSize":"heading-2"} /-->
+	<!-- wp:query-title {"type":"search","fontSize":"heading-2","fontFamily":"inter","style":{"typography":{"fontStyle":"normal","fontWeight":"600"}}} /-->
 
 	<!-- wp:search {"label":"<?php esc_html_e( 'Search', 'wporg' ); ?>","showLabel":false,"placeholder":"<?php esc_html_e( 'Type your search keyword', 'wporg' ); ?>","width":100,"widthUnit":"%","buttonText":"<?php esc_html_e( 'Search', 'wporg' ); ?>","buttonPosition":"button-inside","buttonUseIcon":true,"query":{"post_type":"post"}} /-->
 </div>

--- a/source/wp-content/themes/wporg-developer-blog/patterns/table-of-contents.php
+++ b/source/wp-content/themes/wporg-developer-blog/patterns/table-of-contents.php
@@ -8,8 +8,8 @@
 ?>
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"},"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}},"border":{"radius":"2px"}},"backgroundColor":"light-grey-2","layout":{"type":"default"}} -->
 <div class="wp-block-group has-light-grey-2-background-color has-background" style="border-radius:2px;margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30);padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
-    <!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1"}},"fontSize":"medium","fontFamily":"ibm-plex-sans"} -->
-    <p class="has-ibm-plex-sans-font-family has-medium-font-size" style="font-style:normal;font-weight:600;line-height:1"><?php esc_html_e( 'Table of Contents', 'wporg' ); ?></p>
+    <!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1"}},"fontSize":"large"} -->
+    <p class="has-large-font-size" style="font-style:normal;font-weight:600;line-height:1"><?php esc_html_e( 'Table of Contents', 'wporg' ); ?></p>
     <!-- /wp:paragraph -->
 
     <!-- wp:table-of-contents {"onlyIncludeCurrentPage":true} /-->

--- a/source/wp-content/themes/wporg-developer-blog/templates/archive.html
+++ b/source/wp-content/themes/wporg-developer-blog/templates/archive.html
@@ -37,7 +37,7 @@
 					<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--50)">
 						<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"default"}} -->
 						<div class="wp-block-group">
-							<!-- wp:post-title {"isLink":true,"fontSize":"heading-3"} /-->
+							<!-- wp:post-title {"isLink":true,"fontSize":"heading-4","fontFamily":"inter","style":{"typography":{"fontStyle":"normal","fontWeight":"600"}}} /-->
 
 							<!-- wp:pattern {"slug":"wporg-developer-blog/post-meta"} /-->
 						</div>

--- a/source/wp-content/themes/wporg-developer-blog/templates/author.html
+++ b/source/wp-content/themes/wporg-developer-blog/templates/author.html
@@ -45,7 +45,7 @@
 					<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--50)">
 						<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"default"}} -->
 						<div class="wp-block-group">
-							<!-- wp:post-title {"isLink":true,"fontSize":"heading-3"} /-->
+							<!-- wp:post-title {"isLink":true,"fontSize":"heading-4","fontFamily":"inter","style":{"typography":{"fontStyle":"normal","fontWeight":"600"}}} /-->
 
 							<!-- wp:pattern {"slug":"wporg-developer-blog/post-meta"} /-->
 						</div>

--- a/source/wp-content/themes/wporg-developer-blog/templates/category.html
+++ b/source/wp-content/themes/wporg-developer-blog/templates/category.html
@@ -37,7 +37,7 @@
 					<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--50)">
 						<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"default"}} -->
 						<div class="wp-block-group">
-							<!-- wp:post-title {"isLink":true,"fontSize":"heading-3"} /-->
+							<!-- wp:post-title {"isLink":true,"fontSize":"heading-4","fontFamily":"inter","style":{"typography":{"fontStyle":"normal","fontWeight":"600"}}} /-->
 
 							<!-- wp:pattern {"slug":"wporg-developer-blog/post-meta"} /-->
 						</div>

--- a/source/wp-content/themes/wporg-developer-blog/templates/home.html
+++ b/source/wp-content/themes/wporg-developer-blog/templates/home.html
@@ -33,7 +33,7 @@
 					<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--50)">
 						<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"default"}} -->
 						<div class="wp-block-group">
-							<!-- wp:post-title {"isLink":true,"fontSize":"heading-3"} /-->
+							<!-- wp:post-title {"isLink":true,"fontSize":"heading-4","fontFamily":"inter","style":{"typography":{"fontStyle":"normal","fontWeight":"600"}}} /-->
 
 							<!-- wp:pattern {"slug":"wporg-developer-blog/post-meta"} /-->
 						</div>

--- a/source/wp-content/themes/wporg-developer-blog/templates/index.html
+++ b/source/wp-content/themes/wporg-developer-blog/templates/index.html
@@ -31,7 +31,7 @@
 					<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--50)">
 						<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"default"}} -->
 						<div class="wp-block-group">
-							<!-- wp:post-title {"isLink":true,"fontSize":"heading-3"} /-->
+							<!-- wp:post-title {"isLink":true,"fontSize":"heading-3","fontWeight":"normal"} /-->
 
 							<!-- wp:pattern {"slug":"wporg-developer-blog/post-meta"} /-->
 						</div>

--- a/source/wp-content/themes/wporg-developer-blog/templates/page.html
+++ b/source/wp-content/themes/wporg-developer-blog/templates/page.html
@@ -14,7 +14,7 @@
 
 <!-- wp:group {"tagName":"article","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"inherit":true,"type":"constrained"}} -->
 <article class="wp-block-group" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
-	<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|50"}}},"className":"is-right-column"} /-->
+	<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|50"}}},"className":"is-right-column","fontSize":"heading-1"} /-->
 
 	<!-- wp:post-content {"layout":{"inherit":true}} /-->
 </article>

--- a/source/wp-content/themes/wporg-developer-blog/templates/search.html
+++ b/source/wp-content/themes/wporg-developer-blog/templates/search.html
@@ -33,7 +33,7 @@
 					<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--50)">
 						<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"default"}} -->
 						<div class="wp-block-group">
-							<!-- wp:post-title {"isLink":true,"fontSize":"heading-3"} /-->
+							<!-- wp:post-title {"isLink":true,"fontSize":"heading-4","fontFamily":"inter","style":{"typography":{"fontStyle":"normal","fontWeight":"600"}}} /-->
 
 							<!-- wp:pattern {"slug":"wporg-developer-blog/post-meta"} /-->
 						</div>

--- a/source/wp-content/themes/wporg-developer-blog/theme.json
+++ b/source/wp-content/themes/wporg-developer-blog/theme.json
@@ -13,8 +13,7 @@
 		"custom": {
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--ibm-plex-sans)",
-					"fontWeight": 600,
+					"fontFamily": "var(--wp--preset--font-family--inter)",
 					"lineHeight": 1.2
 				},
 				"level-1": {
@@ -111,12 +110,12 @@
 				},
 				{
 					"name": "Heading 4",
-					"size": "22px",
+					"size": "24px",
 					"slug": "heading-4"
 				},
 				{
 					"name": "Heading 3",
-					"size": "26px",
+					"size": "29px",
 					"slug": "heading-3"
 				},
 				{
@@ -134,6 +133,20 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/post-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontSize": "36px",
+					"lineHeight": "1.3"
+				}
+			},
+			"core/query-title": {
+				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--eb-garamond)",
+					"fontSize": "36px",
+					"lineHeight": "1.3"
+				}
+			},
 			"core/code": {
 				"border": {
 					"radius": "var(--wp--custom--form--border--radius) !important"
@@ -153,6 +166,37 @@
 			"wporg/notice": {
 				"border": {
 					"radius": "var(--wp--custom--form--border--radius)"
+				}
+			}
+		},
+		"elements": {
+			"h2": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--heading-3)",
+					"fontWeight": "600"
+				},
+				"spacing": {
+					"margin": {
+						"top": "0",
+						"bottom": "var(--wp--style--block-gap)"
+					}
+				}
+			},
+			"h3": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--heading-4)",
+					"fontWeight": "600"
+				}
+			},
+			"h4": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--heading-5)",
+					"fontWeight": "600"
+				}
+			},
+			"h5": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--heading-6)"
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #57 

The typography for headings was [recently updated](https://github.com/WordPress/wporg-developer/pull/493)  on the Developer Resources site. The Developer Blog is designed to match the aesthetic of Developer Resources, so this PR applies the same typography updates here.

- IBM Plex Sans → EB Garamond (for H1)
- IBM Plex Sans → Inter (all other headings)

| Before (Home) | After (Home) |
|-|-|
|![developer wordpress org_news_ (1)](https://github.com/WordPress/wporg-developer-blog/assets/4832319/c6e9bf8e-07a8-4c0c-8da4-b02ffa07dd2e)|![localhost_8888_ (1)](https://github.com/WordPress/wporg-developer-blog/assets/4832319/78fdcec5-e181-431f-bbca-ad2f251638ad)|

| Before (Single) | After (Single) |
|-|-|
|![developer wordpress org_news_2023_11_20_getting-started-with-the-command-palette-api_](https://github.com/WordPress/wporg-developer-blog/assets/4832319/c82d5f64-52c9-4d39-90ee-1f67e1fecc64)|![localhost_8888_2023_11_getting-started-with-the-command-palette-api_](https://github.com/WordPress/wporg-developer-blog/assets/4832319/5a96d8bb-3ae8-4d48-9c98-6ae802cd1dc7)|

Note that the Subscribe block does not work in the local environment, and the local nav is not an accurate reflection of the live site. Nothing changed there. 