### PR TITLE
Add temporary fix for code syntax highlighting.

### DIFF
--- a/source/wp-content/themes/wporg-developer-blog/functions.php
+++ b/source/wp-content/themes/wporg-developer-blog/functions.php
@@ -10,6 +10,7 @@ add_action( 'after_setup_theme', __NAMESPACE__ . '\editor_setup' );
 add_filter( 'excerpt_length', __NAMESPACE__ . '\customize_excerpt_length', 10 );
 add_filter( 'render_block_core/search', __NAMESPACE__ . '\search_block_add_search_action', 10, 2 );
 add_filter( 'render_block_core/post-author-name', __NAMESPACE__ . '\author_name_block_update_link_to_profile_text', 9, 2 );
+add_filter( 'render_block_core/code', __NAMESPACE__ . '\code_block_add_line_breaks', 10, 1 );
 
 // Enable Jetpack opengraph by default so we can customize it.
 add_filter( 'jetpack_enable_open_graph', '__return_true' );
@@ -86,6 +87,21 @@ function search_block_add_search_action( $block_content, $block ) {
 	}
 
 	return $block_content;
+}
+
+/**
+ * Replace breaks with new lines in all Code blocks on the front end.
+ * This filter fixes an issue in the Code Syntax Highlighting Block.
+ *
+ * @param string $block_content The block content about to be filtered.
+ * @return string The filtered block content.
+ */
+function code_block_add_line_breaks( $block_content ) {
+	return str_ireplace(
+		[ '<br>', '<br/>', '<br />' ],
+		"\n",
+		$block_content
+	);
 }
 
 /**


### PR DESCRIPTION
The Developer Blog uses the [Code Syntax Block](https://wordpress.org/plugins/code-syntax-block/) plugin to provide syntax highlighting to all Code blocks. This has worked great until recently, where new lines are replaced with `<br>` elements in the code. The plugin does not parse these `<br>` elements as actual line breaks, thinking they are part of the code, which results in the following: 

| Expected | Actual |
|-|-|
|<img width="840" alt="image" src="https://github.com/WordPress/wporg-developer-blog/assets/4832319/32291649-412c-4c53-bcc1-526b1b1a1139">|<img width="818" alt="image" src="https://github.com/WordPress/wporg-developer-blog/assets/4832319/ab4a133c-ce93-4472-abbb-003d960d95d7">|

As a temporary solution, this PR implements a filter for the Code block, replacing all `<br>` with `\n`. 