### PR TITLE
Fix local navigation styling bleeding into global navigation

### DIFF
--- a/source/wp-content/themes/wporg-developer-blog/style.css
+++ b/source/wp-content/themes/wporg-developer-blog/style.css
@@ -43,11 +43,11 @@ kbd {
 /*
  * Fix local navigation submenu styles.
  */
-.wp-block-navigation ul {
+.wp-block-wporg-local-navigation-bar .wp-block-navigation ul {
     padding: 0 !important;
 }
 
-.wp-block-navigation .wp-block-navigation__submenu-container {
+.wp-block-wporg-local-navigation-bar .wp-block-navigation .wp-block-navigation__submenu-container {
     border: 0 !important;
     background-color: #1c2024 !important;
 }

--- a/source/wp-content/themes/wporg-developer-blog/style.css
+++ b/source/wp-content/themes/wporg-developer-blog/style.css
@@ -41,18 +41,6 @@ kbd {
 }
 
 /*
- * Fix local navigation submenu styles.
- */
-.wp-block-wporg-local-navigation-bar .wp-block-navigation ul {
-    padding: 0 !important;
-}
-
-.wp-block-wporg-local-navigation-bar .wp-block-navigation .wp-block-navigation__submenu-container {
-    border: 0 !important;
-    background-color: #1c2024 !important;
-}
-
-/*
  * Improve the styling of the RSS block.
  */
 .wp-block-rss .wp-block-rss__item {


### PR DESCRIPTION
I noticed when working on https://github.com/WordPress/wporg-mu-plugins/pull/606 that the submenus in the global navigation on the Developer Blog were not displaying correctly. This ended up being due to some styling for the local nav that was not specific enough. This PR fixes that. 

| Current | With this PR |
|-|-|
|<img width="555" alt="image" src="https://github.com/WordPress/wporg-developer-blog/assets/4832319/a00163c2-67fa-4fc3-8f08-be8395785b20">|<img width="555" alt="image" src="https://github.com/WordPress/wporg-developer-blog/assets/4832319/94a9d121-ff2c-4bdd-9feb-f8d8f9a056f2">|