### PR TITLE
Introduce a new Snippets CPT and two associated taxonomies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,10 @@ phpcs.xml.dist
 # Ignore everything in source...
 /source/wp-content/*
 /source/wp-content/themes/*
+/source/wp-content/plugins/*
 
 # ...except the actual source of this project.
 !/source/wp-content/themes
 !/source/wp-content/themes/wporg-developer-blog
+!/source/wp-content/plugins
+!/source/wp-content/plugins/wporg-developer-blog-snippets

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -13,7 +13,8 @@
 		"./source/wp-content/plugins/code-syntax-block",
 		"./source/wp-content/plugins/gutenberg",
 		"./source/wp-content/plugins/jetpack",
-		"./source/wp-content/plugins/wordpress-importer"
+		"./source/wp-content/plugins/wordpress-importer",
+		"./source/wp-content/plugins/wporg-developer-blog-snippets"
 	],
 	"themes": [
 		"./source/wp-content/themes/wporg-developer-blog",

--- a/source/wp-content/plugins/wporg-developer-blog-snippets/index.php
+++ b/source/wp-content/plugins/wporg-developer-blog-snippets/index.php
@@ -18,7 +18,8 @@ add_action(
 	'init',
 	function() : void {
 		$post_type = 'snippets';
-		$tax       = 'coding-lang';
+		$lang_tax  = 'coding-lang';
+		$api_tax   = 'api';
 
 		// Register the custom post type.
 		$cpt_args = [
@@ -33,12 +34,36 @@ add_action(
 			'show_in_rest' => true,
 			'menu_icon'    => 'dashicons-editor-code',
 			'supports'     => [ 'title', 'editor', 'author', 'thumbnail' ],
+			'template'     => [
+				[
+					'core/paragraph',
+					[
+						'placeholder' => __( 'Describe your use case for this snippet', 'wporg' )
+					],
+				],
+				[ 'core/code' ],
+				[
+					'core/heading',
+					[
+						'level'   => 2,
+						'content' => 'Relevant links',
+					],
+				],
+				[ 'core/list' ],
+				[
+					'core/paragraph',
+					[
+						'align'   => 'right',
+						'content' => '<em>Please add props here</em>'
+					],
+				],
+			],
 		];
 
 		register_post_type( $post_type, $cpt_args );
 
-		// Register the custom taxonomy
-		$tax_args = [
+		// Register the coding lang taxonomy
+		$lang_tax_args = [
 			'public'       => true,
 			'labels'       => [
 				'name'          => _x( 'Coding languages', 'taxonomy general name', 'wporg' ),
@@ -48,8 +73,44 @@ add_action(
 			],
 			'show_in_rest' => true,
 		];
-\
-		register_taxonomy( $tax, $post_type, $tax_args );
+		register_taxonomy( $lang_tax, $post_type, $lang_tax_args );
 
+		// Register the API taxonomy
+		$api_tax_args = [
+			'public'       => true,
+			'labels'       => [
+				'name'          => _x( 'APIs', 'taxonomy general name', 'wporg' ),
+				'singular_name' => _x( 'API', 'taxonomy singular name', 'wporg' ),
+				'add_new_item'  => __( 'Add New API', 'wporg' ),
+				'not_found'     => __( 'No APIs found', 'wporg' ),
+			],
+			'show_in_rest' => true,
+		];
+		register_taxonomy( $api_tax, $post_type, $api_tax_args );
+	}
+);
+
+// Filter snippets title to be prefixed.
+add_filter(
+	'the_title',
+	function( $title, $post_id ) {
+		if ( 'snippets' === get_post_type( $post_id ) ) {
+			return __( 'Snippet: ', 'wporg' ) . $title;
+		}
+		return $title;
+	},
+	10,
+	2
+);
+
+// Add the snippets post type to the main RSS feed.
+add_filter(
+	'request',
+	function( $query_vars ) {
+		$post_type = 'snippets';
+		if ( isset( $query_vars['feed'] ) && ! isset( $query_vars['post_type'] ) ) {
+			$query_vars['post_type'] = [ 'post', $post_type ];
+		}
+		return $query_vars;
 	}
 );

--- a/source/wp-content/plugins/wporg-developer-blog-snippets/index.php
+++ b/source/wp-content/plugins/wporg-developer-blog-snippets/index.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Plugin Name: Developer Blog Snippets
+ * Plugin URI:  https://github.com/WordPress/wporg-developer-blog
+ * Description: Custom post type and taxonomy to introduce snippets to the developer blog.
+ * Version: 1.0.0
+ * Author: WordPress.org
+ * Author URI: https://wordpress.org/
+ * License:      GPL2
+ * License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain: wporg
+ */
+
+/**
+ * Register the CPT and tax for snippets.
+ */
+add_action(
+	'init',
+	function() : void {
+		$post_type = 'snippets';
+		$tax       = 'coding-lang';
+
+		// Register the custom post type.
+		$cpt_args = [
+			'labels'       => [
+				'name'          => _x( 'Snippets', 'Post type general name', 'wporg' ),
+				'singular_name' => _x( 'Snippet', 'Post type singular name', 'wporg' ),
+				'add_new'       => __( 'Add New Snippet', 'wporg' ),
+			],
+			'public'       => true,
+			'has_archive'  => true,
+			'hierarchical' => false,
+			'show_in_rest' => true,
+			'menu_icon'    => 'dashicons-editor-code',
+			'supports'     => [ 'title', 'editor', 'author', 'thumbnail' ],
+		];
+
+		register_post_type( $post_type, $cpt_args );
+
+		// Register the custom taxonomy
+		$tax_args = [
+			'public'       => true,
+			'labels'       => [
+				'name'          => _x( 'Coding languages', 'taxonomy general name', 'wporg' ),
+				'singular_name' => _x( 'Coding language', 'taxonomy singular name', 'wporg' ),
+				'add_new_item'  => __( 'Add New Coding language', 'wporg' ),
+				'not_found'     => __( 'No Coding languages found', 'wporg' ),
+			],
+			'show_in_rest' => true,
+		];
+\
+		register_taxonomy( $tax, $post_type, $tax_args );
+
+	}
+);

--- a/source/wp-content/plugins/wporg-developer-blog-snippets/index.php
+++ b/source/wp-content/plugins/wporg-developer-blog-snippets/index.php
@@ -95,7 +95,10 @@ add_filter(
 	'the_title',
 	function( $title, $post_id ) {
 		if ( 'snippets' === get_post_type( $post_id ) ) {
-			return __( 'Snippet: ', 'wporg' ) . $title;
+			/*
+			 * Translators: Prefix for all titles of Snippets.
+			 */
+			return sprintf( __( 'Snippet: %s', 'wporg' ), $title );
 		}
 		return $title;
 	},

--- a/source/wp-content/plugins/wporg-developer-blog-snippets/wporg-developer-blog-snippets.php
+++ b/source/wp-content/plugins/wporg-developer-blog-snippets/wporg-developer-blog-snippets.php
@@ -38,7 +38,7 @@ add_action(
 				[
 					'core/paragraph',
 					[
-						'placeholder' => __( 'Describe your use case for this snippet', 'wporg' )
+						'placeholder' => __( 'Describe your use case for this snippet', 'wporg' ),
 					],
 				],
 				[ 'core/code' ],
@@ -54,7 +54,7 @@ add_action(
 					'core/paragraph',
 					[
 						'align'   => 'right',
-						'content' => '<em>Please add props here</em>'
+						'content' => '<em>Please add props here</em>',
 					],
 				],
 			],


### PR DESCRIPTION
This PR introduces a plugin to register a new Snippets CPT for the developer blog as well as Coding Languages and APIs taxonomies. 

There are additional filters to include Snippets in the main RSS feed and to prefix the title with "Snippet: ".

